### PR TITLE
Correct missing "!" after call to -resize/-thumbnail.

### DIFF
--- a/lib/Horde/Image/Im.php
+++ b/lib/Horde/Image/Im.php
@@ -261,7 +261,7 @@ class Horde_Image_Im extends Horde_Image_Base
         } else {
             $this->_postSrcOperations[] =
                 ($keepProfile ? '-resize' : '-thumbnail')
-                . sprintf(' %dx%d', $width, $height);
+                . sprintf(' %dx%d!', $width, $height);
         }
 
         // Refresh the data


### PR DESCRIPTION
This was a regression since https://github.com/horde/horde/commit/01a11ccd37149101d67e0b20261fa48ab07dae13