### PR TITLE
Fix Array and string offset access syntax with curly braces is deprec…

### DIFF
--- a/lib/Horde/Image/Exif/Parser/Gps.php
+++ b/lib/Horde/Image/Exif/Parser/Gps.php
@@ -152,7 +152,7 @@ class Horde_Image_Exif_Parser_Gps extends Horde_Image_Exif_Parser_Base
         case 'ASCII':
             // Latitude Reference, Longitude Reference
             if ($tag == '0001' || $tag == '0003') {
-                $data = ($data{1} == $data{2} && $data{1} == $data{3}) ? $data{0} : $data;
+                $data = ($data[1] == $data[2] && $data[1] == $data[3]) ? $data[0] : $data;
             }
             break;
 


### PR DESCRIPTION
…ated

With PHP 7.4.0RC4
```
There was 1 error:

1) Horde_Image_Exif_BundledTest::testExtract
Array and string offset access syntax with curly braces is deprecated

/work/GIT/horde/Image/lib/Horde/Image/Exif/Parser/Gps.php:155
/usr/share/pear/Horde/Test/Autoload.php:51
/usr/share/pear/Horde/Test/Autoload.php:51
/work/GIT/horde/Image/lib/Horde/Image/Exif/Bundled.php:492
/work/GIT/horde/Image/lib/Horde/Image/Exif/Bundled.php:249
/work/GIT/horde/Image/lib/Horde/Image/Exif/Bundled.php:47
/work/GIT/horde/Image/test/Horde/Image/Exif/TestBase.php:53

```
