### PR TITLE
feat: Add PixelReader interface and Threshold filter

### DIFF
--- a/src/Driver/GdResource.php
+++ b/src/Driver/GdResource.php
@@ -15,11 +15,12 @@ use Horde\Image\Filter\Gamma;
 use Horde\Image\Filter\Grayscale;
 use Horde\Image\Filter\Negate;
 use Horde\Image\Filter\Sepia;
+use Horde\Image\Filter\Threshold;
 use Horde\Image\Geometry\Rectangle;
 use Horde\Image\Geometry\Size;
 use GdImage;
 
-final class GdResource implements ImageResource
+final class GdResource implements ImageResource, PixelReader
 {
     public function __construct(
         private GdImage $gd,
@@ -44,6 +45,22 @@ final class GdResource implements ImageResource
     public function gd(): GdImage
     {
         return $this->gd;
+    }
+
+    /** @return array{int, int, int} */
+    public function getPixelRgb(int $x, int $y): array
+    {
+        $rgb = imagecolorat($this->gd, $x, $y);
+        if ($rgb === false) {
+            return [0, 0, 0];
+        }
+        return [($rgb >> 16) & 0xFF, ($rgb >> 8) & 0xFF, $rgb & 0xFF];
+    }
+
+    public function getLuminance(int $x, int $y): int
+    {
+        [$r, $g, $b] = $this->getPixelRgb($x, $y);
+        return (int) round(0.299 * $r + 0.587 * $g + 0.114 * $b);
     }
 
     public function size(): Size
@@ -157,8 +174,28 @@ final class GdResource implements ImageResource
             ),
             $filter instanceof Gamma => imagegammacorrect($this->gd, 1.0, $filter->gamma),
             $filter instanceof Sepia => $this->applySepiaFilter($filter->threshold),
+            $filter instanceof Threshold => $this->applyThreshold($filter->level),
             default => throw new DriverException('Filter not supported by GdDriver: ' . $filter::class),
         };
+    }
+
+    private function applyThreshold(int $level): void
+    {
+        $w = imagesx($this->gd);
+        $h = imagesy($this->gd);
+        $black = imagecolorallocate($this->gd, 0, 0, 0);
+        $white = imagecolorallocate($this->gd, 255, 255, 255);
+
+        for ($y = 0; $y < $h; $y++) {
+            for ($x = 0; $x < $w; $x++) {
+                $rgb = imagecolorat($this->gd, $x, $y);
+                $r = ($rgb >> 16) & 0xFF;
+                $g = ($rgb >> 8) & 0xFF;
+                $b = $rgb & 0xFF;
+                $lum = (int) round(0.299 * $r + 0.587 * $g + 0.114 * $b);
+                imagesetpixel($this->gd, $x, $y, $lum < $level ? $black : $white);
+            }
+        }
     }
 
     private function applySepiaFilter(float $threshold): void

--- a/src/Driver/ImagickResource.php
+++ b/src/Driver/ImagickResource.php
@@ -20,12 +20,13 @@ use Horde\Image\Filter\Negate;
 use Horde\Image\Filter\Pixelate;
 use Horde\Image\Filter\Sepia;
 use Horde\Image\Filter\Sharpen;
+use Horde\Image\Filter\Threshold;
 use Horde\Image\Geometry\Rectangle;
 use Horde\Image\Geometry\Size;
 use Imagick;
 use ImagickPixel;
 
-final class ImagickResource implements ImageResource
+final class ImagickResource implements ImageResource, PixelReader
 {
     public function __construct(
         private Imagick $imagick,
@@ -117,6 +118,7 @@ final class ImagickResource implements ImageResource
             ),
             $filter instanceof Negate => $clone->imagick->negateImage(false),
             $filter instanceof Pixelate => $clone->applyPixelate($filter->size),
+            $filter instanceof Threshold => $clone->imagick->thresholdImage($filter->level * 257),
             $filter instanceof Modulate => $clone->imagick->modulateImage(
                 $filter->brightness,
                 $filter->saturation,
@@ -145,6 +147,20 @@ final class ImagickResource implements ImageResource
     public function imagick(): Imagick
     {
         return $this->imagick;
+    }
+
+    /** @return array{int, int, int} */
+    public function getPixelRgb(int $x, int $y): array
+    {
+        $pixel = $this->imagick->getImagePixelColor($x, $y);
+        $color = $pixel->getColor();
+        return [(int) $color['r'], (int) $color['g'], (int) $color['b']];
+    }
+
+    public function getLuminance(int $x, int $y): int
+    {
+        [$r, $g, $b] = $this->getPixelRgb($x, $y);
+        return (int) round(0.299 * $r + 0.587 * $g + 0.114 * $b);
     }
 
     public function withImagick(Imagick $imagick): static

--- a/src/Driver/PixelReader.php
+++ b/src/Driver/PixelReader.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Contract for per-pixel read access to image data.
+ *
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ */
+
+namespace Horde\Image\Driver;
+
+interface PixelReader
+{
+    /**
+     * @return array{int, int, int} RGB values 0-255
+     */
+    public function getPixelRgb(int $x, int $y): array;
+
+    /**
+     * BT.601 luminance: 0.299*R + 0.587*G + 0.114*B
+     *
+     * @return int Luminance 0-255
+     */
+    public function getLuminance(int $x, int $y): int;
+}

--- a/src/Driver/PngResource.php
+++ b/src/Driver/PngResource.php
@@ -12,7 +12,7 @@ use Horde\Image\Filter\Filter;
 use Horde\Image\Geometry\Rectangle;
 use Horde\Image\Geometry\Size;
 
-final class PngResource implements ImageResource
+final class PngResource implements ImageResource, PixelReader
 {
     /** @var array<int, array<int, array{int, int, int}>> row => col => [r, g, b] */
     private array $pixels;
@@ -72,6 +72,18 @@ final class PngResource implements ImageResource
             return $this->pixels[$y][$x];
         }
         return [0, 0, 0];
+    }
+
+    /** @return array{int, int, int} */
+    public function getPixelRgb(int $x, int $y): array
+    {
+        return $this->getPixel($x, $y);
+    }
+
+    public function getLuminance(int $x, int $y): int
+    {
+        [$r, $g, $b] = $this->getPixel($x, $y);
+        return (int) round(0.299 * $r + 0.587 * $g + 0.114 * $b);
     }
 
     public function resize(Size $size): static

--- a/src/Filter/Threshold.php
+++ b/src/Filter/Threshold.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Binarize an image by thresholding pixel luminance.
+ *
+ * Pixels with luminance below the threshold become black (0,0,0),
+ * pixels at or above become white (255,255,255).
+ *
+ * Copyright 2026 The Horde Project (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (LGPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/lgpl21.
+ */
+
+namespace Horde\Image\Filter;
+
+final readonly class Threshold implements Filter
+{
+    /**
+     * @param int $level 0-255; pixels below become black, at or above become white
+     */
+    public function __construct(
+        public int $level = 128,
+    ) {}
+}


### PR DESCRIPTION
## Summary
- New `PixelReader` interface for uniform per-pixel RGB/luminance access
- Implemented in `GdResource`, `ImagickResource`, `PngResource`
- New `Threshold` binarization filter (used by barcode detection in horde/Barcode)

Refs horde/Barcode#1

## Test plan
- Verify `getPixelRgb()` returns correct values on known-color images
- Verify `getLuminance()` matches BT.601 formula
- Apply Threshold filter, confirm output is strictly black/white